### PR TITLE
[refactor] 토큰 응답을 헤더로 수정한다

### DIFF
--- a/src/docs/asciidoc/auth/oauth.adoc
+++ b/src/docs/asciidoc/auth/oauth.adoc
@@ -42,6 +42,9 @@ include::{snippets}/OAuthApi/Login/Success/http-request.adoc[]
 include::{snippets}/OAuthApi/Login/Success/request-fields.adoc[]
 
 HTTP Response
+include::{snippets}/OAuthApi/Login/Success/http-response.adoc[]
+include::{snippets}/OAuthApi/Login/Success/response-headers.adoc[]
+include::{snippets}/OAuthApi/Login/Success/response-cookies.adoc[]
 include::{snippets}/OAuthApi/Login/Success/response-body.adoc[]
 include::{snippets}/OAuthApi/Login/Success/response-fields.adoc[]
 

--- a/src/docs/asciidoc/auth/token-reissue.adoc
+++ b/src/docs/asciidoc/auth/token-reissue.adoc
@@ -10,6 +10,7 @@
 HTTP Request
 include::{snippets}/TokenReissueApi/Failure/Case1/http-request.adoc[]
 include::{snippets}/TokenReissueApi/Failure/Case1/request-headers.adoc[]
+include::{snippets}/TokenReissueApi/Failure/Case1/request-cookies.adoc[]
 
 HTTP Response
 include::{snippets}/TokenReissueApi/Failure/Case1/response-body.adoc[]
@@ -18,6 +19,7 @@ include::{snippets}/TokenReissueApi/Failure/Case1/response-body.adoc[]
 HTTP Request
 include::{snippets}/TokenReissueApi/Failure/Case2/http-request.adoc[]
 include::{snippets}/TokenReissueApi/Failure/Case2/request-headers.adoc[]
+include::{snippets}/TokenReissueApi/Failure/Case2/request-cookies.adoc[]
 
 HTTP Response
 include::{snippets}/TokenReissueApi/Failure/Case2/response-body.adoc[]
@@ -26,7 +28,9 @@ include::{snippets}/TokenReissueApi/Failure/Case2/response-body.adoc[]
 HTTP Request
 include::{snippets}/TokenReissueApi/Success/http-request.adoc[]
 include::{snippets}/TokenReissueApi/Success/request-headers.adoc[]
+include::{snippets}/TokenReissueApi/Success/request-cookies.adoc[]
 
 HTTP Response
-include::{snippets}/TokenReissueApi/Success/response-body.adoc[]
-include::{snippets}/TokenReissueApi/Success/response-fields.adoc[]
+include::{snippets}/TokenReissueApi/Success/http-response.adoc[]
+include::{snippets}/TokenReissueApi/Success/response-headers.adoc[]
+include::{snippets}/TokenReissueApi/Success/response-cookies.adoc[]

--- a/src/main/java/com/kgu/studywithme/auth/application/usecase/ReissueTokenUseCase.java
+++ b/src/main/java/com/kgu/studywithme/auth/application/usecase/ReissueTokenUseCase.java
@@ -16,11 +16,14 @@ public class ReissueTokenUseCase {
 
     @StudyWithMeWritableTransactional
     public AuthToken invoke(final ReissueTokenCommand command) {
-        if (isAnonymousRefreshToken(command.memberId(), command.refreshToken())) {
+        validateMemberToken(command.memberId(), command.refreshToken());
+        return tokenIssuer.reissueAuthorityToken(command.memberId());
+    }
+
+    private void validateMemberToken(final Long memberId, final String refreshToken) {
+        if (isAnonymousRefreshToken(memberId, refreshToken)) {
             throw StudyWithMeException.type(AuthErrorCode.INVALID_TOKEN);
         }
-
-        return tokenIssuer.reissueAuthorityToken(command.memberId());
     }
 
     private boolean isAnonymousRefreshToken(final Long memberId, final String refreshToken) {

--- a/src/main/java/com/kgu/studywithme/auth/presentation/OAuthApiController.java
+++ b/src/main/java/com/kgu/studywithme/auth/presentation/OAuthApiController.java
@@ -9,6 +9,7 @@ import com.kgu.studywithme.auth.application.usecase.query.GetOAuthLink;
 import com.kgu.studywithme.auth.domain.model.AuthMember;
 import com.kgu.studywithme.auth.domain.model.oauth.OAuthProvider;
 import com.kgu.studywithme.auth.presentation.dto.request.OAuthLoginRequest;
+import com.kgu.studywithme.auth.presentation.dto.response.LoginResponse;
 import com.kgu.studywithme.auth.utils.TokenResponseWriter;
 import com.kgu.studywithme.global.aop.CheckAuthUser;
 import com.kgu.studywithme.global.dto.ResponseWrapper;
@@ -52,7 +53,7 @@ public class OAuthApiController {
 
     @Operation(summary = "Authorization Code를 통해서 Provider별 인증을 위한 EndPoint")
     @PostMapping("/login/{provider}")
-    public ResponseEntity<AuthMember.MemberInfo> login(
+    public ResponseEntity<LoginResponse> login(
             @PathVariable final String provider,
             @RequestBody @Valid final OAuthLoginRequest request,
             final HttpServletResponse response
@@ -66,7 +67,11 @@ public class OAuthApiController {
         tokenResponseWriter.applyAccessToken(response, authMember.token().accessToken());
         tokenResponseWriter.applyRefreshToken(response, authMember.token().refreshToken());
 
-        return ResponseEntity.ok(authMember.member());
+        return ResponseEntity.ok(new LoginResponse(
+                authMember.member().id(),
+                authMember.member().nickname(),
+                authMember.member().email()
+        ));
     }
 
     @Operation(summary = "로그아웃 EndPoint")

--- a/src/main/java/com/kgu/studywithme/auth/presentation/OAuthApiController.java
+++ b/src/main/java/com/kgu/studywithme/auth/presentation/OAuthApiController.java
@@ -9,11 +9,13 @@ import com.kgu.studywithme.auth.application.usecase.query.GetOAuthLink;
 import com.kgu.studywithme.auth.domain.model.AuthMember;
 import com.kgu.studywithme.auth.domain.model.oauth.OAuthProvider;
 import com.kgu.studywithme.auth.presentation.dto.request.OAuthLoginRequest;
+import com.kgu.studywithme.auth.utils.TokenResponseWriter;
 import com.kgu.studywithme.global.aop.CheckAuthUser;
 import com.kgu.studywithme.global.dto.ResponseWrapper;
 import com.kgu.studywithme.global.resolver.ExtractPayload;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OAuthApiController {
     private final GetOAuthLinkUseCase getOAuthLinkUseCase;
     private final OAuthLoginUseCase oAuthLoginUseCase;
+    private final TokenResponseWriter tokenResponseWriter;
     private final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "Provider별 OAuth 인증을 위한 URL을 받는 EndPoint")
@@ -49,16 +52,21 @@ public class OAuthApiController {
 
     @Operation(summary = "Authorization Code를 통해서 Provider별 인증을 위한 EndPoint")
     @PostMapping("/login/{provider}")
-    public AuthMember login(
+    public ResponseEntity<AuthMember.MemberInfo> login(
             @PathVariable final String provider,
-            @RequestBody @Valid final OAuthLoginRequest request
+            @RequestBody @Valid final OAuthLoginRequest request,
+            final HttpServletResponse response
     ) {
-        return oAuthLoginUseCase.invoke(new OAuthLoginCommand(
+        final AuthMember authMember = oAuthLoginUseCase.invoke(new OAuthLoginCommand(
                 OAuthProvider.from(provider),
                 request.authorizationCode(),
                 request.redirectUri(),
                 request.state()
         ));
+        tokenResponseWriter.applyAccessToken(response, authMember.token().accessToken());
+        tokenResponseWriter.applyRefreshToken(response, authMember.token().refreshToken());
+
+        return ResponseEntity.ok(authMember.member());
     }
 
     @Operation(summary = "로그아웃 EndPoint")

--- a/src/main/java/com/kgu/studywithme/auth/presentation/TokenReissueApiController.java
+++ b/src/main/java/com/kgu/studywithme/auth/presentation/TokenReissueApiController.java
@@ -3,14 +3,19 @@ package com.kgu.studywithme.auth.presentation;
 import com.kgu.studywithme.auth.application.usecase.ReissueTokenUseCase;
 import com.kgu.studywithme.auth.application.usecase.command.ReissueTokenCommand;
 import com.kgu.studywithme.auth.domain.model.AuthToken;
+import com.kgu.studywithme.auth.utils.TokenResponseWriter;
 import com.kgu.studywithme.global.resolver.ExtractPayload;
-import com.kgu.studywithme.global.resolver.ExtractToken;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.kgu.studywithme.auth.utils.TokenResponseWriter.REFRESH_TOKEN_COOKIE;
 
 @Tag(name = "1-2. 토큰 재발급 API")
 @RestController
@@ -18,13 +23,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/token/reissue")
 public class TokenReissueApiController {
     private final ReissueTokenUseCase reissueTokenUseCase;
+    private final TokenResponseWriter tokenResponseWriter;
 
     @Operation(summary = "RefreshToken을 통한 토큰 재발급 EndPoint")
     @PostMapping
-    public AuthToken reissueToken(
+    public ResponseEntity<Void> reissueToken(
             @ExtractPayload final Long memberId,
-            @ExtractToken final String refreshToken
+            @CookieValue(REFRESH_TOKEN_COOKIE) final String refreshToken,
+            final HttpServletResponse response
     ) {
-        return reissueTokenUseCase.invoke(new ReissueTokenCommand(memberId, refreshToken));
+        final AuthToken authToken = reissueTokenUseCase.invoke(new ReissueTokenCommand(memberId, refreshToken));
+        tokenResponseWriter.applyAccessToken(response, authToken.accessToken());
+        tokenResponseWriter.applyRefreshToken(response, authToken.refreshToken());
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/kgu/studywithme/auth/presentation/dto/response/LoginResponse.java
+++ b/src/main/java/com/kgu/studywithme/auth/presentation/dto/response/LoginResponse.java
@@ -1,0 +1,8 @@
+package com.kgu.studywithme.auth.presentation.dto.response;
+
+public record LoginResponse(
+        Long id,
+        String nickname,
+        String email
+) {
+}

--- a/src/main/java/com/kgu/studywithme/auth/utils/TokenResponseWriter.java
+++ b/src/main/java/com/kgu/studywithme/auth/utils/TokenResponseWriter.java
@@ -1,0 +1,37 @@
+package com.kgu.studywithme.auth.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.boot.web.server.Cookie.SameSite.STRICT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
+@Component
+public class TokenResponseWriter {
+    public static final String REFRESH_TOKEN_COOKIE = "refresh_token";
+    private static final String AUTHORIZATION_TOKEN_PREFIX = "Bearer";
+
+    private final long cookieAge;
+
+    public TokenResponseWriter(@Value("${jwt.refresh-token-validity}") final long cookieAge) {
+        this.cookieAge = cookieAge;
+    }
+
+    public void applyAccessToken(final HttpServletResponse response, final String accessToken) {
+        response.setHeader(AUTHORIZATION, String.join(" ", AUTHORIZATION_TOKEN_PREFIX, accessToken));
+    }
+
+    public void applyRefreshToken(final HttpServletResponse response, final String refreshToken) {
+        final ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+                .maxAge(cookieAge)
+                .sameSite(STRICT.attributeValue())
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/test/java/com/kgu/studywithme/acceptance/CommonRequestFixture.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/CommonRequestFixture.java
@@ -1,6 +1,7 @@
 package com.kgu.studywithme.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import static com.kgu.studywithme.auth.utils.TokenResponseWriter.REFRESH_TOKEN_COOKIE;
 import static io.restassured.http.ContentType.JSON;
 import static io.restassured.http.ContentType.MULTIPART;
 
@@ -63,6 +65,20 @@ public class CommonRequestFixture {
         return request(given -> given
                 .contentType(JSON)
                 .auth().oauth2(accessToken)
+                .when()
+                .post(path)
+        );
+    }
+
+    public static ValidatableResponse postRequest(
+            final String accessToken,
+            final String refreshToken,
+            final String path
+    ) {
+        return request(given -> given
+                .contentType(JSON)
+                .auth().oauth2(accessToken)
+                .cookie(new Cookie.Builder(REFRESH_TOKEN_COOKIE, refreshToken).build())
                 .when()
                 .post(path)
         );

--- a/src/test/java/com/kgu/studywithme/acceptance/auth/AuthAcceptanceFixture.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/auth/AuthAcceptanceFixture.java
@@ -46,13 +46,13 @@ public class AuthAcceptanceFixture {
         return postRequest(accessToken, uri);
     }
 
-    public static ValidatableResponse 토큰을_재발급받는다(final String refreshToken) {
+    public static ValidatableResponse 토큰을_재발급받는다(final String accessToken, final String refreshToken) {
         final String uri = UriComponentsBuilder
                 .fromPath("/api/token/reissue")
                 .build()
                 .toUri()
                 .getPath();
 
-        return postRequest(refreshToken, uri);
+        return postRequest(accessToken, refreshToken, uri);
     }
 }

--- a/src/test/java/com/kgu/studywithme/acceptance/favorite/FavoriteAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/favorite/FavoriteAcceptanceTest.java
@@ -25,7 +25,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         studyId = 스터디를_생성하고_PK를_얻는다(accessToken, SPRING);
     }
 

--- a/src/test/java/com/kgu/studywithme/acceptance/file/FileUploadAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/file/FileUploadAcceptanceTest.java
@@ -21,7 +21,7 @@ public class FileUploadAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
     }
 
     @Nested

--- a/src/test/java/com/kgu/studywithme/acceptance/member/MemberAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/member/MemberAcceptanceTest.java
@@ -34,7 +34,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         @Test
         @DisplayName("사용자 정보를 수정한다")
         void signUpApi() {
-            final String accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+            final String accessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
             사용자_정보를_수정한다(accessToken, GHOST)
                     .statusCode(NO_CONTENT.value());
         }

--- a/src/test/java/com/kgu/studywithme/acceptance/member/MemberQueryAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/member/MemberQueryAcceptanceTest.java
@@ -53,7 +53,7 @@ public class MemberQueryAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     void setUp() {
         memberId = JIWON.회원가입을_진행한다();
-        memberAccessToken = JIWON.로그인을_진행한다().token().accessToken();
+        memberAccessToken = JIWON.로그인을_진행하고_AccessToken을_추출한다();
     }
 
     @Nested
@@ -123,9 +123,9 @@ public class MemberQueryAcceptanceTest extends AcceptanceTest {
 
             @BeforeEach
             void setUp() {
-                hostAccessToken = GHOST.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+                hostAccessToken = GHOST.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
                 final Long participantId = ANONYMOUS.회원가입을_진행한다();
-                participantAccessToken = ANONYMOUS.로그인을_진행한다().token().accessToken();
+                participantAccessToken = ANONYMOUS.로그인을_진행하고_AccessToken을_추출한다();
 
                 final Long studyId = SPRING.스터디를_생성한다(hostAccessToken);
                 스터디_참여_신청을_한다(memberAccessToken, studyId);
@@ -163,7 +163,7 @@ public class MemberQueryAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            hostAccessToken = GHOST.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+            hostAccessToken = GHOST.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
             studies = Stream.of(LINE_INTERVIEW, SPRING, KAFKA)
                     .map(study -> study.스터디를_생성한다(hostAccessToken))
                     .toList();

--- a/src/test/java/com/kgu/studywithme/acceptance/member/MemberReportAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/member/MemberReportAcceptanceTest.java
@@ -21,7 +21,7 @@ public class MemberReportAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        reporterAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        reporterAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         reporteeId = GHOST.회원가입을_진행한다();
     }
 

--- a/src/test/java/com/kgu/studywithme/acceptance/member/MemberReviewAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/member/MemberReviewAcceptanceTest.java
@@ -36,9 +36,9 @@ public class MemberReviewAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     void setUp() {
         hostId = JIWON.회원가입을_진행한다();
-        hostAccessToken = JIWON.로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.로그인을_진행하고_AccessToken을_추출한다();
         memberId = GHOST.회원가입을_진행한다();
-        final String memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+        final String memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
 
         studyId = 스터디를_생성하고_PK를_얻는다(hostAccessToken, SPRING);
         스터디_참여_신청을_한다(memberAccessToken, studyId);

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyAcceptanceTest.java
@@ -25,7 +25,7 @@ public class StudyAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
     }
 
     @Nested

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyAttendanceAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyAttendanceAcceptanceTest.java
@@ -28,9 +28,9 @@ public class StudyAttendanceAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         memberId = GHOST.회원가입을_진행한다();
-        final String memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+        final String memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
 
         studyId = SPRING.스터디를_생성한다(hostAccessToken);
         스터디_참여_신청을_한다(memberAccessToken, studyId);

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyNoticeAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyNoticeAcceptanceTest.java
@@ -37,9 +37,9 @@ public class StudyNoticeAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         final Long memberId = GHOST.회원가입을_진행한다();
-        memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+        memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
 
         studyId = SPRING.스터디를_생성한다(hostAccessToken);
         스터디_참여_신청을_한다(memberAccessToken, studyId);
@@ -132,7 +132,7 @@ public class StudyNoticeAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("참여자가 아니면 공지사항에 댓글을 작성할 수 없다")
             void memberIsNotParticipant() {
-                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
                 스터디_공지사항에_댓글을_작성한다(anonymousAccessToken, noticeId)
                         .statusCode(ONLY_PARTICIPANT_CAN_WRITE_COMMENT.getStatus().value())
                         .body("errorCode", is(ONLY_PARTICIPANT_CAN_WRITE_COMMENT.getErrorCode()))

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyParticipantAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyParticipantAcceptanceTest.java
@@ -43,13 +43,13 @@ public class StudyParticipantAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
 
         idOfMemberA = GHOST.회원가입을_진행한다();
-        accessTokenOfMemberA = GHOST.로그인을_진행한다().token().accessToken();
+        accessTokenOfMemberA = GHOST.로그인을_진행하고_AccessToken을_추출한다();
 
         idOfMemberB = ANONYMOUS.회원가입을_진행한다();
-        accessTokenOfMemberB = ANONYMOUS.로그인을_진행한다().token().accessToken();
+        accessTokenOfMemberB = ANONYMOUS.로그인을_진행하고_AccessToken을_추출한다();
 
         studyId = SPRING.스터디를_생성한다(hostAccessToken);
         twoCapacityAndZeroPolicyStudyId = KAFKA.스터디를_생성한다(hostAccessToken);

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyQueryAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyQueryAcceptanceTest.java
@@ -55,7 +55,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
     @BeforeEach
     void setUp() {
         hostId = JIWON.회원가입을_진행한다();
-        hostAccessToken = JIWON.로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.로그인을_진행하고_AccessToken을_추출한다();
     }
 
     @Nested
@@ -96,7 +96,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
                         .body("participants[0].id", is(hostId.intValue()));
 
                 final Long ghostId = GHOST.회원가입을_진행한다();
-                final String ghostAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+                final String ghostAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
                 GHOST가_스터디에_참여한다(ghostId, ghostAccessToken);
                 스터디_기본_정보를_조회한다(studyId)
                         .statusCode(OK.value())
@@ -126,7 +126,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
                         .body("graduateCount", is(0));
 
                 final Long ghostId = GHOST.회원가입을_진행한다();
-                final String ghostAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+                final String ghostAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
                 GHOST가_스터디를_졸업한다(ghostId, ghostAccessToken);
                 스터디_리뷰를_조회한다(studyId)
                         .statusCode(OK.value())
@@ -158,7 +158,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @BeforeEach
             void setUp() {
                 memberId = GHOST.회원가입을_진행한다();
-                final String memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+                final String memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
                 스터디_참여_신청을_한다(memberAccessToken, studyId);
             }
 
@@ -201,9 +201,9 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @BeforeEach
             void setUp() {
                 idOfMemberA = GHOST.회원가입을_진행한다();
-                accessTokenOfMemberA = GHOST.로그인을_진행한다().token().accessToken();
+                accessTokenOfMemberA = GHOST.로그인을_진행하고_AccessToken을_추출한다();
                 idOfMemberB = ANONYMOUS.회원가입을_진행한다();
-                accessTokenOfMemberB = ANONYMOUS.로그인을_진행한다().token().accessToken();
+                accessTokenOfMemberB = ANONYMOUS.로그인을_진행하고_AccessToken을_추출한다();
             }
 
             @Test
@@ -246,7 +246,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @BeforeEach
             void setUp() {
                 memberId = GHOST.회원가입을_진행한다();
-                memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+                memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
                 스터디_참여_신청을_한다(memberAccessToken, studyId);
             }
 
@@ -297,7 +297,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @BeforeEach
             void setUp() {
                 memberId = GHOST.회원가입을_진행한다();
-                final String memberAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+                final String memberAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
 
                 스터디_참여_신청을_한다(memberAccessToken, studyId);
                 스터디_신청자에_대한_참여를_승인한다(hostAccessToken, studyId, memberId);
@@ -309,7 +309,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("스터디 참여자가 아니면 출석 정보를 조회할 수 없다")
             void memberIsNotParticipant() {
-                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
                 스터디_출석_정보를_조회한다(anonymousAccessToken, studyId)
                         .statusCode(MEMBER_IS_NOT_PARTICIPANT.getStatus().value())
                         .body("errorCode", is(MEMBER_IS_NOT_PARTICIPANT.getErrorCode()))
@@ -375,7 +375,7 @@ public class StudyQueryAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("스터디 참여자가 아니면 주차별 정보를 조회할 수 없다")
             void memberIsNotParticipant() {
-                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+                final String anonymousAccessToken = DUMMY9.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
                 스터디_주차별_정보를_조회한다(anonymousAccessToken, studyId)
                         .statusCode(MEMBER_IS_NOT_PARTICIPANT.getStatus().value())
                         .body("errorCode", is(MEMBER_IS_NOT_PARTICIPANT.getErrorCode()))

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyReviewAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyReviewAcceptanceTest.java
@@ -30,9 +30,9 @@ public class StudyReviewAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        final String hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        final String hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         final Long participantId = GHOST.회원가입을_진행한다();
-        participantAccessToken = GHOST.로그인을_진행한다().token().accessToken();
+        participantAccessToken = GHOST.로그인을_진행하고_AccessToken을_추출한다();
         studyId = KAFKA.스터디를_생성한다(hostAccessToken);
         스터디_참여_신청을_한다(participantAccessToken, studyId);
         스터디_신청자에_대한_참여를_승인한다(hostAccessToken, studyId, participantId);

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudySearchAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudySearchAcceptanceTest.java
@@ -1,7 +1,5 @@
 package com.kgu.studywithme.acceptance.study;
 
-import com.kgu.studywithme.auth.domain.model.AuthMember;
-import com.kgu.studywithme.auth.domain.model.AuthToken;
 import com.kgu.studywithme.common.AcceptanceTest;
 import com.kgu.studywithme.common.config.DatabaseCleanerAllCallbackExtension;
 import com.kgu.studywithme.common.fixture.MemberFixture;
@@ -55,7 +53,7 @@ public class StudySearchAcceptanceTest extends AcceptanceTest {
 
     @BeforeAll
     static void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         studies = Stream.of(RABBITMQ, OOP, REDIS, JSP, TOEIC, LINE_INTERVIEW)
                 .collect(Collectors.toMap(
                         study -> study,
@@ -66,9 +64,7 @@ public class StudySearchAcceptanceTest extends AcceptanceTest {
                 .toList();
 
         final List<String> participantAccessTokens = Stream.of(DUMMY1, DUMMY2, DUMMY3, DUMMY4, DUMMY5)
-                .map(MemberFixture::로그인을_진행한다)
-                .map(AuthMember::token)
-                .map(AuthToken::accessToken)
+                .map(MemberFixture::로그인을_진행하고_AccessToken을_추출한다)
                 .toList();
 
         for (StudyFixture fixture : studies.keySet()) {

--- a/src/test/java/com/kgu/studywithme/acceptance/study/StudyWeeklyAcceptanceTest.java
+++ b/src/test/java/com/kgu/studywithme/acceptance/study/StudyWeeklyAcceptanceTest.java
@@ -31,7 +31,7 @@ public class StudyWeeklyAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행한다().token().accessToken();
+        hostAccessToken = JIWON.회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다();
         studyId = SPRING.스터디를_생성한다(hostAccessToken);
     }
 

--- a/src/test/java/com/kgu/studywithme/auth/presentation/TokenReissueApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/auth/presentation/TokenReissueApiControllerTest.java
@@ -2,27 +2,31 @@ package com.kgu.studywithme.auth.presentation;
 
 import com.kgu.studywithme.auth.exception.AuthErrorCode;
 import com.kgu.studywithme.common.ControllerTest;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import static com.kgu.studywithme.auth.utils.TokenResponseWriter.REFRESH_TOKEN_COOKIE;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentRequest;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
+import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithRefreshToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
-import static com.kgu.studywithme.common.utils.TokenUtils.REFRESH_TOKEN;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyRefreshTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyRefreshToken;
 import static com.kgu.studywithme.common.utils.TokenUtils.createTokenResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("Auth -> TokenReissueApiController 테스트")
@@ -41,7 +45,8 @@ class TokenReissueApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyRefreshTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken())
+                    .cookie(new Cookie(REFRESH_TOKEN_COOKIE, applyRefreshToken()));
 
             // then
             final AuthErrorCode expectedError = AuthErrorCode.EXPIRED_TOKEN;
@@ -53,6 +58,7 @@ class TokenReissueApiControllerTest extends ControllerTest {
                                     "TokenReissueApi/Failure/Case1",
                                     getDocumentRequest(),
                                     getDocumentResponse(),
+                                    getHeaderWithAccessToken(),
                                     getHeaderWithRefreshToken(),
                                     getExceptionResponseFields()
                             )
@@ -68,7 +74,8 @@ class TokenReissueApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyRefreshTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken())
+                    .cookie(new Cookie(REFRESH_TOKEN_COOKIE, applyRefreshToken()));
 
             // then
             final AuthErrorCode expectedError = AuthErrorCode.INVALID_TOKEN;
@@ -80,6 +87,7 @@ class TokenReissueApiControllerTest extends ControllerTest {
                                     "TokenReissueApi/Failure/Case2",
                                     getDocumentRequest(),
                                     getDocumentResponse(),
+                                    getHeaderWithAccessToken(),
                                     getHeaderWithRefreshToken(),
                                     getExceptionResponseFields()
                             )
@@ -96,28 +104,28 @@ class TokenReissueApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyRefreshTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken())
+                    .cookie(new Cookie(REFRESH_TOKEN_COOKIE, applyRefreshToken()));
 
             // then
             mockMvc.perform(requestBuilder)
-                    .andExpectAll(
-                            status().isOk(),
-                            jsonPath("$.accessToken").exists(),
-                            jsonPath("$.accessToken").value(ACCESS_TOKEN),
-                            jsonPath("$.refreshToken").exists(),
-                            jsonPath("$.refreshToken").value(REFRESH_TOKEN)
-                    )
+                    .andExpectAll(status().isNoContent())
                     .andDo(
                             document(
                                     "TokenReissueApi/Success",
                                     getDocumentRequest(),
                                     getDocumentResponse(),
+                                    getHeaderWithAccessToken(),
                                     getHeaderWithRefreshToken(),
-                                    responseFields(
-                                            fieldWithPath("accessToken")
-                                                    .description("새로 발급된 Access Token (Expire - 2시간)"),
-                                            fieldWithPath("refreshToken")
-                                                    .description("새로 발급된 Refresh Token (Expire - 2주)")
+                                    responseHeaders(
+                                            headerWithName(AUTHORIZATION)
+                                                    .description("Access Token"),
+                                            headerWithName(SET_COOKIE)
+                                                    .description("Set Refresh Token")
+                                    ),
+                                    responseCookies(
+                                            cookieWithName(REFRESH_TOKEN_COOKIE)
+                                                    .description("Refresh Token")
                                     )
                             )
                     );

--- a/src/test/java/com/kgu/studywithme/common/config/TestWebBeanConfiguration.java
+++ b/src/test/java/com/kgu/studywithme/common/config/TestWebBeanConfiguration.java
@@ -1,5 +1,6 @@
 package com.kgu.studywithme.common.config;
 
+import com.kgu.studywithme.auth.utils.TokenResponseWriter;
 import com.kgu.studywithme.global.config.CorsProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -11,5 +12,10 @@ public class TestWebBeanConfiguration {
     @Bean
     public CorsProperties corsProperties() {
         return new CorsProperties(Set.of("http://localhost:8080"));
+    }
+
+    @Bean
+    public TokenResponseWriter tokenResponseWriter() {
+        return new TokenResponseWriter(1234);
     }
 }

--- a/src/test/java/com/kgu/studywithme/common/fixture/MemberFixture.java
+++ b/src/test/java/com/kgu/studywithme/common/fixture/MemberFixture.java
@@ -18,10 +18,12 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import static com.kgu.studywithme.acceptance.auth.AuthAcceptanceFixture.Google_OAuth_로그인을_진행한다;
+import static com.kgu.studywithme.auth.utils.TokenResponseWriter.REFRESH_TOKEN_COOKIE;
 import static com.kgu.studywithme.category.domain.model.Category.APTITUDE_NCS;
 import static com.kgu.studywithme.category.domain.model.Category.CERTIFICATION;
 import static com.kgu.studywithme.category.domain.model.Category.ETC;
@@ -34,6 +36,7 @@ import static com.kgu.studywithme.common.utils.OAuthUtils.REDIRECT_URI;
 import static com.kgu.studywithme.common.utils.TokenUtils.ACCESS_TOKEN;
 import static com.kgu.studywithme.common.utils.TokenUtils.REFRESH_TOKEN;
 import static com.kgu.studywithme.member.domain.model.Gender.MALE;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Getter
 @RequiredArgsConstructor
@@ -156,7 +159,79 @@ public enum MemberFixture {
         );
     }
 
-    public AuthMember 회원가입_후_Google_OAuth_로그인을_진행한다() {
+    public Long 회원가입을_진행한다() {
+        return MemberAcceptanceFixture.회원가입을_진행한다(this)
+                .extract()
+                .jsonPath()
+                .getLong("memberId");
+    }
+
+    public String 로그인을_진행하고_AccessToken을_추출한다() {
+        final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
+                GOOGLE_PROVIDER,
+                getAuthorizationCodeByIdentifier(this.getEmail().getValue()),
+                REDIRECT_URI,
+                UUID.randomUUID().toString()
+        );
+
+        final String token = response
+                .extract()
+                .header(AUTHORIZATION);
+
+        return token.split(" ")[1];
+    }
+
+    public String 로그인을_진행하고_RefreshToken을_추출한다() {
+        final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
+                GOOGLE_PROVIDER,
+                getAuthorizationCodeByIdentifier(this.getEmail().getValue()),
+                REDIRECT_URI,
+                UUID.randomUUID().toString()
+        );
+
+        return response
+                .extract()
+                .cookie(REFRESH_TOKEN_COOKIE);
+    }
+
+    public List<String> 회원가입_후_Google_OAuth_로그인을_진행하고_Token을_추출한다() {
+        MemberAcceptanceFixture.회원가입을_진행한다(this);
+
+        final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
+                GOOGLE_PROVIDER,
+                getAuthorizationCodeByIdentifier(this.getEmail().getValue()),
+                REDIRECT_URI,
+                UUID.randomUUID().toString()
+        );
+
+        final String accessToken = response
+                .extract()
+                .header(AUTHORIZATION)
+                .split(" ")[1];
+        final String refreshToken = response
+                .extract()
+                .cookie(REFRESH_TOKEN_COOKIE);
+        return List.of(accessToken, refreshToken);
+    }
+
+    public String 회원가입_후_Google_OAuth_로그인을_진행하고_AccessToken을_추출한다() {
+        MemberAcceptanceFixture.회원가입을_진행한다(this);
+
+        final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
+                GOOGLE_PROVIDER,
+                getAuthorizationCodeByIdentifier(this.getEmail().getValue()),
+                REDIRECT_URI,
+                UUID.randomUUID().toString()
+        );
+
+        final String token = response
+                .extract()
+                .header(AUTHORIZATION);
+
+        return token.split(" ")[1];
+    }
+
+    public String 회원가입_후_Google_OAuth_로그인을_진행하고_RefreshToken을_추출한다() {
         MemberAcceptanceFixture.회원가입을_진행한다(this);
 
         final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
@@ -168,26 +243,6 @@ public enum MemberFixture {
 
         return response
                 .extract()
-                .as(AuthMember.class);
-    }
-
-    public Long 회원가입을_진행한다() {
-        return MemberAcceptanceFixture.회원가입을_진행한다(this)
-                .extract()
-                .jsonPath()
-                .getLong("memberId");
-    }
-
-    public AuthMember 로그인을_진행한다() {
-        final ValidatableResponse response = Google_OAuth_로그인을_진행한다(
-                GOOGLE_PROVIDER,
-                getAuthorizationCodeByIdentifier(this.getEmail().getValue()),
-                REDIRECT_URI,
-                UUID.randomUUID().toString()
-        );
-
-        return response
-                .extract()
-                .as(AuthMember.class);
+                .cookie(REFRESH_TOKEN_COOKIE);
     }
 }

--- a/src/test/java/com/kgu/studywithme/common/utils/RestDocsSpecificationUtils.java
+++ b/src/test/java/com/kgu/studywithme/common/utils/RestDocsSpecificationUtils.java
@@ -5,7 +5,10 @@ import org.springframework.restdocs.operation.preprocess.OperationResponsePrepro
 import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.restdocs.snippet.Snippet;
 
+import static com.kgu.studywithme.auth.utils.TokenResponseWriter.REFRESH_TOKEN_COOKIE;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -30,8 +33,8 @@ public class RestDocsSpecificationUtils {
     }
 
     public static Snippet getHeaderWithRefreshToken() {
-        return requestHeaders(
-                headerWithName(AUTHORIZATION).description("Refresh Token")
+        return requestCookies(
+                cookieWithName(REFRESH_TOKEN_COOKIE).description("Refresh Token")
         );
     }
 

--- a/src/test/java/com/kgu/studywithme/common/utils/TokenUtils.java
+++ b/src/test/java/com/kgu/studywithme/common/utils/TokenUtils.java
@@ -10,12 +10,12 @@ public class TokenUtils {
     public static final String REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwiaWF0IjoxNjc3OTM3MjI0LCJleHAiOjE2Nzg1NDIwMjR9.doqGa5Hcq6chjER1y5brJEv81z0njcJqeYxJb159ZX4";
     public static final long EXPIRES_IN = 3000;
 
-    public static String applyAccessTokenToAuthorizationHeader() {
+    public static String applyAccessToken() {
         return String.join(" ", BEARER_TOKEN, ACCESS_TOKEN);
     }
 
-    public static String applyRefreshTokenToAuthorizationHeader() {
-        return String.join(" ", BEARER_TOKEN, REFRESH_TOKEN);
+    public static String applyRefreshToken() {
+        return REFRESH_TOKEN;
     }
 
     public static AuthToken createTokenResponse() {

--- a/src/test/java/com/kgu/studywithme/favorite/presentation/FavoriteApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/favorite/presentation/FavoriteApiControllerTest.java
@@ -13,7 +13,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -45,7 +45,7 @@ class FavoriteApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final FavoriteErrorCode expectedError = FavoriteErrorCode.ALREADY_LIKE_MARKED;
@@ -77,7 +77,7 @@ class FavoriteApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -116,7 +116,7 @@ class FavoriteApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final FavoriteErrorCode expectedError = FavoriteErrorCode.FAVORITE_MARKING_NOT_FOUND;
@@ -150,7 +150,7 @@ class FavoriteApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/file/presentation/FileUploadApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/file/presentation/FileUploadApiControllerTest.java
@@ -16,7 +16,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -49,7 +49,7 @@ class FileUploadApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "studyWeeklyContentImage");
 
             // then
@@ -92,7 +92,7 @@ class FileUploadApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "studyWeeklyContentImage");
 
             // then
@@ -143,7 +143,7 @@ class FileUploadApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "studyDescriptionImage");
 
             // then
@@ -186,7 +186,7 @@ class FileUploadApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "studyDescriptionImage");
 
             // then

--- a/src/test/java/com/kgu/studywithme/member/presentation/MemberApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/member/presentation/MemberApiControllerTest.java
@@ -20,7 +20,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static com.kgu.studywithme.member.domain.model.Gender.MALE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -199,7 +199,7 @@ class MemberApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .patch(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 

--- a/src/test/java/com/kgu/studywithme/member/presentation/MemberPrivateInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/member/presentation/MemberPrivateInformationApiControllerTest.java
@@ -20,7 +20,7 @@ import static com.kgu.studywithme.common.fixture.StudyFixture.SPRING;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentRequest;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -65,7 +65,7 @@ class MemberPrivateInformationApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .get(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -137,7 +137,7 @@ class MemberPrivateInformationApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .get(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -195,7 +195,7 @@ class MemberPrivateInformationApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .get(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/memberreport/presentation/MemberReportApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/memberreport/presentation/MemberReportApiControllerTest.java
@@ -14,7 +14,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -49,7 +49,7 @@ class MemberReportApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REPORTEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -87,7 +87,7 @@ class MemberReportApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REPORTEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 

--- a/src/test/java/com/kgu/studywithme/memberreview/presentation/MemberReviewApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/memberreview/presentation/MemberReviewApiControllerTest.java
@@ -15,7 +15,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -53,7 +53,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -93,7 +93,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -133,7 +133,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -171,7 +171,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -224,7 +224,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -264,7 +264,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -304,7 +304,7 @@ class MemberReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, REVIEWEE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 

--- a/src/test/java/com/kgu/studywithme/study/presentation/StudyApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/presentation/StudyApiControllerTest.java
@@ -20,7 +20,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -80,7 +80,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -138,7 +138,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -200,7 +200,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                     .post(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(OFFLINE_STUDY_REQUEST));
 
@@ -302,7 +302,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -369,7 +369,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -436,7 +436,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -503,7 +503,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(ONLINE_STUDY_REQUEST));
 
@@ -583,7 +583,7 @@ class StudyApiControllerTest extends ControllerTest {
             );
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(request));
 
@@ -647,7 +647,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(OFFLINE_STUDY_REQUEST));
 
@@ -723,7 +723,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -754,7 +754,7 @@ class StudyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/study/presentation/StudyInformationApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/presentation/StudyInformationApiControllerTest.java
@@ -25,7 +25,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.constr
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentRequest;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static com.kgu.studywithme.study.domain.model.RecruitmentStatus.ON;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -213,7 +213,7 @@ class StudyInformationApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/study/presentation/StudyInformationOnlyParticipantApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/presentation/StudyInformationOnlyParticipantApiControllerTest.java
@@ -30,7 +30,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static com.kgu.studywithme.studyattendance.domain.model.AttendanceStatus.ABSENCE;
 import static com.kgu.studywithme.studyattendance.domain.model.AttendanceStatus.ATTENDANCE;
 import static com.kgu.studywithme.studyattendance.domain.model.AttendanceStatus.LATE;
@@ -70,7 +70,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -106,7 +106,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -159,7 +159,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.MEMBER_IS_NOT_PARTICIPANT;
@@ -241,7 +241,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -312,7 +312,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.MEMBER_IS_NOT_PARTICIPANT;
@@ -369,7 +369,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -422,7 +422,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.MEMBER_IS_NOT_PARTICIPANT;
@@ -474,7 +474,7 @@ class StudyInformationOnlyParticipantApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/study/presentation/StudySearchApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/study/presentation/StudySearchApiControllerTest.java
@@ -19,7 +19,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.constr
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentRequest;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static com.kgu.studywithme.study.domain.model.RecruitmentStatus.ON;
 import static com.kgu.studywithme.study.domain.model.StudyType.ONLINE;
 import static com.kgu.studywithme.study.utils.search.PagingConstants.SLICE_PER_PAGE;
@@ -136,7 +136,7 @@ class StudySearchApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .get(BASE_URL)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .param("sort", "date")
                     .param("page", String.valueOf(0))
                     .param("type", "online");

--- a/src/test/java/com/kgu/studywithme/studyattendance/presentation/StudyAttendanceApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyattendance/presentation/StudyAttendanceApiControllerTest.java
@@ -17,7 +17,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static com.kgu.studywithme.studyattendance.domain.model.AttendanceStatus.ATTENDANCE;
 import static com.kgu.studywithme.studyattendance.domain.model.AttendanceStatus.NON_ATTENDANCE;
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +60,7 @@ class StudyAttendanceApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, PARTICIPANT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -102,7 +102,7 @@ class StudyAttendanceApiControllerTest extends ControllerTest {
             final ManualAttendanceRequest request = new ManualAttendanceRequest(1, NON_ATTENDANCE.getValue());
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, ANONYMOUS_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(request));
 
@@ -147,7 +147,7 @@ class StudyAttendanceApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, ANONYMOUS_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -191,7 +191,7 @@ class StudyAttendanceApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, PARTICIPANT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 

--- a/src/test/java/com/kgu/studywithme/studynotice/presentation/StudyNoticeApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studynotice/presentation/StudyNoticeApiControllerTest.java
@@ -15,7 +15,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -56,7 +56,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -96,7 +96,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -156,7 +156,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -200,7 +200,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -254,7 +254,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -290,7 +290,7 @@ class StudyNoticeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studynotice/presentation/StudyNoticeCommentApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studynotice/presentation/StudyNoticeCommentApiControllerTest.java
@@ -15,7 +15,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -51,7 +51,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -91,7 +91,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, NOTICE_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -139,7 +139,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, NOTICE_ID, COMMENT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -181,7 +181,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, NOTICE_ID, COMMENT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -230,7 +230,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, NOTICE_ID, COMMENT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyNoticeErrorCode expectedError = StudyNoticeErrorCode.ONLY_WRITER_CAN_DELETE_NOTICE_COMMENT;
@@ -266,7 +266,7 @@ class StudyNoticeCommentApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, NOTICE_ID, COMMENT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyparticipant/presentation/DelegateHostAuthorityApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyparticipant/presentation/DelegateHostAuthorityApiControllerTest.java
@@ -15,7 +15,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -52,7 +52,7 @@ class DelegateHostAuthorityApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, PARTICIPANT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -88,7 +88,7 @@ class DelegateHostAuthorityApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, PARTICIPANT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.STUDY_IS_TERMINATED;
@@ -124,7 +124,7 @@ class DelegateHostAuthorityApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, ANONYMOUS_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.NON_PARTICIPANT_CANNOT_BE_HOST;
@@ -160,7 +160,7 @@ class DelegateHostAuthorityApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, ANONYMOUS_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.SELF_DELEGATING_NOT_ALLOWED;
@@ -196,7 +196,7 @@ class DelegateHostAuthorityApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, PARTICIPANT_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyApplyApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyApplyApiControllerTest.java
@@ -14,7 +14,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -48,7 +48,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.STUDY_IS_NOT_RECRUITING_NOW;
@@ -82,7 +82,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.STUDY_HOST_CANNOT_APPLY;
@@ -116,7 +116,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.ALREADY_APPLY_OR_PARTICIPATE;
@@ -150,7 +150,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.ALREADY_LEAVE_OR_GRADUATED;
@@ -182,7 +182,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -222,7 +222,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.APPLIER_NOT_FOUND;
@@ -256,7 +256,7 @@ class StudyApplyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyFinalizeApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyFinalizeApiControllerTest.java
@@ -14,7 +14,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -51,7 +51,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.MEMBER_IS_NOT_PARTICIPANT;
@@ -85,7 +85,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.HOST_CANNOT_LEAVE_STUDY;
@@ -119,7 +119,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -164,7 +164,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.MEMBER_IS_NOT_PARTICIPANT;
@@ -198,7 +198,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.HOST_CANNOT_GRADUATE_STUDY;
@@ -232,7 +232,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.PARTICIPANT_NOT_MEET_GRADUATION_POLICY;
@@ -266,7 +266,7 @@ class StudyFinalizeApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyParticipantDecisionApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyparticipant/presentation/StudyParticipantDecisionApiControllerTest.java
@@ -17,7 +17,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -55,7 +55,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -91,7 +91,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.STUDY_IS_TERMINATED;
@@ -127,7 +127,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.APPLIER_NOT_FOUND;
@@ -163,7 +163,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyParticipantErrorCode expectedError = StudyParticipantErrorCode.STUDY_CAPACITY_ALREADY_FULL;
@@ -199,7 +199,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)
@@ -245,7 +245,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -284,7 +284,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(new RejectParticipationRequest("")));
 
@@ -327,7 +327,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -369,7 +369,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -411,7 +411,7 @@ class StudyParticipantDecisionApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, APPLIER_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 

--- a/src/test/java/com/kgu/studywithme/studyreview/presentation/StudyReviewApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyreview/presentation/StudyReviewApiControllerTest.java
@@ -15,7 +15,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -54,7 +54,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -94,7 +94,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -132,7 +132,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .post(BASE_URL, STUDY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -187,7 +187,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, REVIEW_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -229,7 +229,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .patch(BASE_URL, STUDY_ID, REVIEW_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .contentType(APPLICATION_JSON)
                     .content(convertObjectToJson(REQUEST));
 
@@ -278,7 +278,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, REVIEW_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyReviewErrorCode expectedError = StudyReviewErrorCode.ONLY_WRITER_CAN_DELETE;
@@ -314,7 +314,7 @@ class StudyReviewApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, REVIEW_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyweekly/presentation/StudyWeeklyApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyweekly/presentation/StudyWeeklyApiControllerTest.java
@@ -23,7 +23,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -81,7 +81,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
                     .file((MockMultipartFile) files2)
                     .file((MockMultipartFile) files3)
                     .file((MockMultipartFile) files4)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("title", STUDY_WEEKLY_1.getTitle())
                     .queryParam("content", STUDY_WEEKLY_1.getContent())
                     .queryParam("startDate", STUDY_WEEKLY_1.getPeriod().getStartDate().format(DATE_TIME_FORMATTER))
@@ -143,7 +143,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
                     .file((MockMultipartFile) files2)
                     .file((MockMultipartFile) files3)
                     .file((MockMultipartFile) files4)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("title", STUDY_WEEKLY_1.getTitle())
                     .queryParam("content", STUDY_WEEKLY_1.getContent())
                     .queryParam("startDate", STUDY_WEEKLY_1.getPeriod().getStartDate().format(DATE_TIME_FORMATTER))
@@ -233,7 +233,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
                     .file((MockMultipartFile) files2)
                     .file((MockMultipartFile) files3)
                     .file((MockMultipartFile) files4)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("title", STUDY_WEEKLY_1.getTitle())
                     .queryParam("content", STUDY_WEEKLY_1.getContent())
                     .queryParam("startDate", STUDY_WEEKLY_1.getPeriod().getStartDate().format(DATE_TIME_FORMATTER))
@@ -299,7 +299,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
                     .file((MockMultipartFile) files2)
                     .file((MockMultipartFile) files3)
                     .file((MockMultipartFile) files4)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("title", STUDY_WEEKLY_1.getTitle())
                     .queryParam("content", STUDY_WEEKLY_1.getContent())
                     .queryParam("startDate", STUDY_WEEKLY_1.getPeriod().getStartDate().format(DATE_TIME_FORMATTER))
@@ -365,7 +365,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
                     .file((MockMultipartFile) files2)
                     .file((MockMultipartFile) files3)
                     .file((MockMultipartFile) files4)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("title", STUDY_WEEKLY_1.getTitle())
                     .queryParam("content", STUDY_WEEKLY_1.getContent())
                     .queryParam("startDate", STUDY_WEEKLY_1.getPeriod().getStartDate().format(DATE_TIME_FORMATTER))
@@ -437,7 +437,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyErrorCode expectedError = StudyErrorCode.MEMBER_IS_NOT_HOST;
@@ -473,7 +473,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             final StudyWeeklyErrorCode expectedError = StudyWeeklyErrorCode.ONLY_LATEST_WEEKLY_CAN_DELETE;
@@ -506,7 +506,7 @@ class StudyWeeklyApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .delete(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader());
+                    .header(AUTHORIZATION, applyAccessToken());
 
             // then
             mockMvc.perform(requestBuilder)

--- a/src/test/java/com/kgu/studywithme/studyweekly/presentation/StudyWeeklySubmitApiControllerTest.java
+++ b/src/test/java/com/kgu/studywithme/studyweekly/presentation/StudyWeeklySubmitApiControllerTest.java
@@ -21,7 +21,7 @@ import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDoc
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getDocumentResponse;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getExceptionResponseFields;
 import static com.kgu.studywithme.common.utils.RestDocsSpecificationUtils.getHeaderWithAccessToken;
-import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessTokenToAuthorizationHeader;
+import static com.kgu.studywithme.common.utils.TokenUtils.applyAccessToken;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -63,7 +63,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file");
 
             // then
@@ -113,7 +113,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file");
 
             // then
@@ -164,7 +164,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file")
                     .queryParam("link", "https://notion.so");
 
@@ -216,7 +216,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "link");
 
             // then
@@ -264,7 +264,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file");
 
             // then
@@ -308,7 +308,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "link")
                     .queryParam("link", "https://notion.so");
 
@@ -372,7 +372,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "link")
                     .queryParam("link", "https://notion.so");
 
@@ -423,7 +423,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file");
 
             // then
@@ -474,7 +474,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file")
                     .queryParam("link", "https://notion.so");
 
@@ -526,7 +526,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "link");
 
             // then
@@ -577,7 +577,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
                     .file((MockMultipartFile) file)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "file")
                     .queryParam("link", "https://notion.so");
 
@@ -625,7 +625,7 @@ class StudyWeeklySubmitApiControllerTest extends ControllerTest {
             // when
             final MockHttpServletRequestBuilder requestBuilder = RestDocumentationRequestBuilders
                     .multipart(BASE_URL, STUDY_ID, WEEKLY_ID)
-                    .header(AUTHORIZATION, applyAccessTokenToAuthorizationHeader())
+                    .header(AUTHORIZATION, applyAccessToken())
                     .queryParam("type", "link")
                     .queryParam("link", "https://notion.so");
 


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용

- 토큰 응답 구조 수정
  - 기존 -> JSON Body
  - 개선 -> `AccessToken = Authorization Header` || `RefreshToken = Cookie(HttpOnly + Secure + SameSite.STRICT)`