### PR TITLE
[fix] Scale Out 후 스케줄링 로직이 중복 실행되는 문제를 해결한다

### DIFF
--- a/src/main/java/com/kgu/studywithme/global/scheduler/UpdateWeeklyAttendanceScheduler.java
+++ b/src/main/java/com/kgu/studywithme/global/scheduler/UpdateWeeklyAttendanceScheduler.java
@@ -2,16 +2,26 @@ package com.kgu.studywithme.global.scheduler;
 
 import com.kgu.studywithme.studyattendance.domain.service.UpdateWeeklyAttendanceBatchProcessor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor
 public class UpdateWeeklyAttendanceScheduler {
+    private final StringRedisTemplate redisTemplate;
     private final UpdateWeeklyAttendanceBatchProcessor updateWeeklyAttendanceBatchProcessor;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void processAbsenceCheckScheduler() {
-        updateWeeklyAttendanceBatchProcessor.checkAbsenceParticipantAndApplyAbsenceScore();
+        if (canExecute()) {
+            updateWeeklyAttendanceBatchProcessor.checkAbsenceParticipantAndApplyAbsenceScore();
+        }
+    }
+
+    private boolean canExecute() {
+        return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent("scheduling", "on", Duration.ofMinutes(5)));
     }
 }


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 정상적으로 프로그램이 동작하나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용

`Redis setnx`를 통해서 Scale Out 후 스케줄링 로직이 중복 실행되는 문제 해결

> https://sjiwon-dev.tistory.com/46